### PR TITLE
解决Android 7.1.1起不能再用Toast的问题（先解决crash）

### DIFF
--- a/app/src/main/java/in/srain/cube/demos/uctoast/TipViewController.java
+++ b/app/src/main/java/in/srain/cube/demos/uctoast/TipViewController.java
@@ -53,8 +53,15 @@ final class TipViewController implements View.OnClickListener, View.OnTouchListe
 
         int flags = 0;
         int type = 0;
+
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            type = WindowManager.LayoutParams.TYPE_TOAST;
+            //解决Android 7.1.1起不能再用Toast的问题（先解决crash）
+            if(Build.VERSION.SDK_INT > 24){
+                type = WindowManager.LayoutParams.TYPE_PHONE;
+            }else{
+                type = WindowManager.LayoutParams.TYPE_TOAST;
+            }
         } else {
             type = WindowManager.LayoutParams.TYPE_PHONE;
         }


### PR DESCRIPTION
官方说明及地址：

https://android.googlesource.com/platform/frameworks/base/+/dc24f93

Prevent apps to overlay other apps via toast windows

It was possible for apps to put toast type windows
that overlay other apps which toast winodws aren't
removed after a timeout.

Now for apps targeting SDK greater than N MR1 to add a
toast window one needs to have a special token. The token
is added by the notificatoion manager service only for
the lifetime of the shown toast and is then removed
including all windows associated with this token. This
prevents apps to add arbitrary toast windows.

Since legacy apps may rely on the ability to directly
add toasts we mitigate by allowing these apps to still
add such windows for unlimited duration if this app is
the currently focused one, i.e. the user interacts with
it then it can overlay itself, otherwise we make sure
these toast windows are removed after a timeout like
a toast would be.

We don't allow more that one toast window per UID being
added at a time which prevents 1) legacy apps to put the
same toast after a timeout to go around our new policy
of hiding toasts after a while; 2) modern apps to reuse
the passed token to add more than one window; Note that
the notification manager shows toasts one at a time.

bug:30150688

Change-Id: Icc8f8dbd060762ae1a7b1720e96c5afdb8aff3fd